### PR TITLE
Expected type 'defaultdict[str | Any]', got 'defaultdict[Any, int]' instead

### DIFF
--- a/trackmania_rl/multiprocess/learner_process.py
+++ b/trackmania_rl/multiprocess/learner_process.py
@@ -115,7 +115,7 @@ def learner_process_fn(
     print(online_network)
     utilities.count_parameters(online_network)
 
-    accumulated_stats: defaultdict[str | typing.Any] = defaultdict(int)
+    accumulated_stats: defaultdict[str, typing.Any] = defaultdict(int)
     accumulated_stats["alltime_min_ms"] = {}
     accumulated_stats["rolling_mean_ms"] = {}
     previous_alltime_min = None

--- a/trackmania_rl/multiprocess/learner_process.py
+++ b/trackmania_rl/multiprocess/learner_process.py
@@ -1,6 +1,7 @@
 """
 This file implements the main training loop, tensorboard statistics tracking, etc...
 """
+
 import copy
 import importlib
 import math
@@ -521,9 +522,9 @@ def learner_process_fn(
                         >= accumulated_stats["cumul_number_single_memories_used_next_target_network_update"]
                     ):
                         accumulated_stats["cumul_number_target_network_updates"] += 1
-                        accumulated_stats[
-                            "cumul_number_single_memories_used_next_target_network_update"
-                        ] += config_copy.number_memories_trained_on_between_target_network_updates
+                        accumulated_stats["cumul_number_single_memories_used_next_target_network_update"] += (
+                            config_copy.number_memories_trained_on_between_target_network_updates
+                        )
                         # print("UPDATE")
                         utilities.soft_copy_param(target_network, online_network, config_copy.soft_update_tau)
             print("", flush=True)


### PR DESCRIPTION
SonarLint shows the warning:
_Expected type 'defaultdict[str | Any]', got 'defaultdict[Any, int]' instead_
on trackmania_rl/multiprocess/learner_process.py:118.
```
accumulated_stats: defaultdict[str | typing.Any] = defaultdict(int)
```
This looks like a typo, the pipe should be a comma.

Fixes #42