### PR TITLE
Explicitly set weights_only argument to torch.load()

### DIFF
--- a/trackmania_rl/multiprocess/collector_process.py
+++ b/trackmania_rl/multiprocess/collector_process.py
@@ -1,6 +1,7 @@
 """
 This file implements a single multithreaded worker that handles a Trackmania game instance and provides rollout results to the learner process.
 """
+
 import importlib
 import time
 from itertools import chain, count, cycle

--- a/trackmania_rl/multiprocess/collector_process.py
+++ b/trackmania_rl/multiprocess/collector_process.py
@@ -40,7 +40,7 @@ def collector_process_fn(
 
     inference_network, uncompiled_inference_network = iqn.make_untrained_iqn_network(config_copy.use_jit, is_inference=True)
     try:
-        inference_network.load_state_dict(torch.load(save_dir / "weights1.torch"))
+        inference_network.load_state_dict(torch.load(f=save_dir / "weights1.torch", weights_only=False))
     except Exception as e:
         print("Worker could not load weights, exception:", e)
 

--- a/trackmania_rl/multiprocess/learner_process.py
+++ b/trackmania_rl/multiprocess/learner_process.py
@@ -126,8 +126,8 @@ def learner_process_fn(
     # ========================================================
     # noinspection PyBroadException
     try:
-        online_network.load_state_dict(torch.load(save_dir / "weights1.torch"))
-        target_network.load_state_dict(torch.load(save_dir / "weights2.torch"))
+        online_network.load_state_dict(torch.load(f=save_dir / "weights1.torch", weights_only=False))
+        target_network.load_state_dict(torch.load(f=save_dir / "weights2.torch", weights_only=False))
         print(" =====================     Learner weights loaded !     ============================")
     except:
         print(" Learner could not load weights")
@@ -168,8 +168,8 @@ def learner_process_fn(
 
     # noinspection PyBroadException
     try:
-        optimizer1.load_state_dict(torch.load(save_dir / "optimizer1.torch"))
-        scaler.load_state_dict(torch.load(save_dir / "scaler.torch"))
+        optimizer1.load_state_dict(torch.load(f=save_dir / "optimizer1.torch", weights_only=False))
+        scaler.load_state_dict(torch.load(f=save_dir / "scaler.torch", weights_only=False))
         print(" =========================     Optimizer loaded !     ================================")
     except:
         print(" Could not load optimizer")

--- a/trackmania_rl/multiprocess/learner_process.py
+++ b/trackmania_rl/multiprocess/learner_process.py
@@ -1,6 +1,7 @@
 """
 This file implements the main training loop, tensorboard statistics tracking, etc...
 """
+
 import copy
 import importlib
 import math
@@ -521,9 +522,9 @@ def learner_process_fn(
                         >= accumulated_stats["cumul_number_single_memories_used_next_target_network_update"]
                     ):
                         accumulated_stats["cumul_number_target_network_updates"] += 1
-                        accumulated_stats[
-                            "cumul_number_single_memories_used_next_target_network_update"
-                        ] += config_copy.number_memories_trained_on_between_target_network_updates
+                        accumulated_stats["cumul_number_single_memories_used_next_target_network_update"] += (
+                            config_copy.number_memories_trained_on_between_target_network_updates
+                        )
                         # print("UPDATE")
                         utilities.soft_copy_param(target_network, online_network, config_copy.soft_update_tau)
             print("", flush=True)


### PR DESCRIPTION
Warning output was:
FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.

Fixes #50