### PR TITLE
Replace deprecated torch.cuda.amp.GradScaler()

### DIFF
--- a/trackmania_rl/agents/iqn.py
+++ b/trackmania_rl/agents/iqn.py
@@ -192,7 +192,7 @@ class Trainer:
         online_network: IQN_Network,
         target_network: IQN_Network,
         optimizer: torch.optim.Optimizer,
-        scaler: torch.cuda.amp.grad_scaler.GradScaler,
+        scaler: torch.amp.GradScaler,
         batch_size: int,
         iqn_n: int,
     ):

--- a/trackmania_rl/agents/iqn.py
+++ b/trackmania_rl/agents/iqn.py
@@ -4,6 +4,7 @@ In this file, we define:
     - The Trainer class, which implements the IQN training logic in method train_on_batch.
     - The Inferer class, which implements utilities for forward propagation with and without exploration.
 """
+
 import copy
 import math
 import random

--- a/trackmania_rl/multiprocess/learner_process.py
+++ b/trackmania_rl/multiprocess/learner_process.py
@@ -159,7 +159,7 @@ def learner_process_fn(
     )
     # optimizer1 = torch_optimizer.Lookahead(optimizer1, k=5, alpha=0.5)
 
-    scaler = torch.cuda.amp.GradScaler()
+    scaler = torch.amp.GradScaler("cuda")
     memory_size, memory_size_start_learn = utilities.from_staircase_schedule(
         config_copy.memory_size_schedule, accumulated_stats["cumul_number_memories_generated"]
     )

--- a/trackmania_rl/multiprocess/learner_process.py
+++ b/trackmania_rl/multiprocess/learner_process.py
@@ -1,6 +1,7 @@
 """
 This file implements the main training loop, tensorboard statistics tracking, etc...
 """
+
 import copy
 import importlib
 import math
@@ -521,9 +522,9 @@ def learner_process_fn(
                         >= accumulated_stats["cumul_number_single_memories_used_next_target_network_update"]
                     ):
                         accumulated_stats["cumul_number_target_network_updates"] += 1
-                        accumulated_stats[
-                            "cumul_number_single_memories_used_next_target_network_update"
-                        ] += config_copy.number_memories_trained_on_between_target_network_updates
+                        accumulated_stats["cumul_number_single_memories_used_next_target_network_update"] += (
+                            config_copy.number_memories_trained_on_between_target_network_updates
+                        )
                         # print("UPDATE")
                         utilities.soft_copy_param(target_network, online_network, config_copy.soft_update_tau)
             print("", flush=True)


### PR DESCRIPTION
Warning output was:
FutureWarning: `torch.cuda.amp.GradScaler(args...)` is deprecated. Please use `torch.amp.GradScaler('cuda', args...)` instead.

Fixes #51