### PR TITLE
Rename PR functions and variables

### DIFF
--- a/scripts/tools/video_stuff/inputs_to_gbx.py
+++ b/scripts/tools/video_stuff/inputs_to_gbx.py
@@ -120,7 +120,7 @@ def close_game(tm_process_id):
 
 
 def request_map(iface, map_path):
-    map_loader.hide_PR_replay(map_path, True)
+    map_loader.hide_personal_record_replay(map_path, True)
     iface.execute_command(f'map "{map_path}"')
 
 
@@ -147,7 +147,7 @@ def main():
         os.mkdir(outputs_folder)
     input_files = [f for f in os.listdir(args.inputs_dir) if os.path.isfile(os.path.join(args.inputs_dir, f))]
     input_files = [f for f in input_files if not os.path.isfile(os.path.join(outputs_folder, f[: f.rfind(".")] + ".Replay.Gbx"))]
-    pr_replay_filename, pr_replay_path = map_loader.PR_replay_from_map_path(args.map_path)
+    pr_replay_filename, pr_replay_path = map_loader.replay_personal_record(args.map_path)
 
     tm_process_id, tm_window_id = launch_game(args.tmi_port)
     signal.signal(signal.SIGINT, lambda: signal_handler(tm_process_id))
@@ -256,7 +256,7 @@ def main():
                 iface.execute_command(f"set countdown_speed " + str(run_speed))
                 iface.execute_command(f"set temp_save_states_collect false")
                 iface.execute_command(f"set skip_map_load_screens true")
-                map_loader.hide_PR_replay(args.map_path, True)
+                map_loader.hide_personal_record_replay(args.map_path, True)
                 if not map_loaded:
                     request_map(iface, args.map_path)
                     map_loaded = True

--- a/scripts/tools/video_stuff/inputs_to_gbx.py
+++ b/scripts/tools/video_stuff/inputs_to_gbx.py
@@ -2,6 +2,7 @@
 Convert a batch of "xxxxxxxx.inputs" to the corresponding "xxxxxx.Replay.Gbx" files.
 Works on Agade's computer, not on pb4's.
 """
+
 import argparse
 import os
 import shutil

--- a/trackmania_rl/map_loader.py
+++ b/trackmania_rl/map_loader.py
@@ -95,22 +95,20 @@ def map_name_from_map_path(map_path):
     return gbx_challenge.map_name
 
 
-def PR_replay_from_map_path(map_path):
-    # PR : Personal Record
-    PR_replay_filename = config_copy.username + "_" + map_name_from_map_path(map_path) + ".Replay.gbx"
-    PR_replay_path = config_copy.trackmania_base_path / "Tracks" / "Replays" / "Autosaves"
-    return PR_replay_filename, PR_replay_path
+def replay_personal_record(map_path):
+    filename = config_copy.username + "_" + map_name_from_map_path(map_path) + ".Replay.gbx"
+    filepath = config_copy.trackmania_base_path / "Tracks" / "Replays" / "Autosaves"
+    return filename, filepath
 
 
-def hide_PR_replay(map_path, is_hide):
-    # PR : Personal Record
-    PR_replay_filename, PR_replay_path = PR_replay_from_map_path(map_path)
+def hide_personal_record_replay(map_path, is_hide):
+    filename, filepath = replay_personal_record(map_path)
     if is_hide:
-        if os.path.isfile(PR_replay_path / PR_replay_filename):
-            os.replace(PR_replay_path / PR_replay_filename, PR_replay_path / (PR_replay_filename + ".bak"))
+        if os.path.isfile(filepath / filename):
+            os.replace(filepath / filename, filepath / (filename + ".bak"))
     else:
-        if os.path.isfile(PR_replay_path / PR_replay_filename + ".bak"):
-            os.replace(PR_replay_path / (PR_replay_filename + ".bak"), PR_replay_path / PR_replay_filename)
+        if os.path.isfile(filepath / filename + ".bak"):
+            os.replace(filepath / (filename + ".bak"), filepath / filename)
 
 
 def get_checkpoint_positions_from_gbx(map_path: str):

--- a/trackmania_rl/tmi_interaction/game_instance_manager.py
+++ b/trackmania_rl/tmi_interaction/game_instance_manager.py
@@ -260,7 +260,7 @@ class GameInstanceManager:
             map_path = map_path.replace("\\", "/")
         else:
             map_path = map_path.replace("/", "\\")
-        map_loader.hide_PR_replay(map_path, True)
+        map_loader.hide_personal_record_replay(map_path, True)
         self.iface.execute_command(f"map {map_path}")
         self.UI_disabled = False
         (

--- a/trackmania_rl/tmi_interaction/game_instance_manager.py
+++ b/trackmania_rl/tmi_interaction/game_instance_manager.py
@@ -135,19 +135,24 @@ class GameInstanceManager:
 
         if config_copy.is_linux:
             self.tm_window_id = None
-            while self.tm_window_id is None: #This outer while is for the edge case where the window may not have had time to be launched
-                window_search_depth=1
-                while True:#This inner while is to try and find the right depth of the window in Xdo().search_windows()
-                    c1 = set(Xdo().search_windows(winname=b"TrackMania Modded", max_depth=window_search_depth+1))
+            while self.tm_window_id is None:  # This outer while is for the edge case where the window may not have had time to be launched
+                window_search_depth = 1
+                while True:  # This inner while is to try and find the right depth of the window in Xdo().search_windows()
+                    c1 = set(Xdo().search_windows(winname=b"TrackMania Modded", max_depth=window_search_depth + 1))
                     c2 = set(Xdo().search_windows(winname=b"TrackMania Modded", max_depth=window_search_depth))
                     c1 = {w_id for w_id in c1 if Xdo().get_pid_window(w_id) == self.tm_process_id}
                     c2 = {w_id for w_id in c2 if Xdo().get_pid_window(w_id) == self.tm_process_id}
                     c1_diff_c2 = c1.difference(c2)
-                    if(len(c1_diff_c2)==1):
+                    if len(c1_diff_c2) == 1:
                         self.tm_window_id = c1_diff_c2.pop()
                         break
-                    elif (len(c1_diff_c2)==0 and len(c1)>0) or window_search_depth>=10: #10 is an arbitrary cutoff in this search we do not fully understand
-                        print("Warning: Worker could not find the window of the game it just launched, stopped at window_search_depth",window_search_depth)
+                    elif (
+                        len(c1_diff_c2) == 0 and len(c1) > 0
+                    ) or window_search_depth >= 10:  # 10 is an arbitrary cutoff in this search we do not fully understand
+                        print(
+                            "Warning: Worker could not find the window of the game it just launched, stopped at window_search_depth",
+                            window_search_depth,
+                        )
                         break
                     window_search_depth += 1
         else:


### PR DESCRIPTION
Warnings were:
- Rename function "foo" to match the regular expression ^[a-z_][a-z0-9_]*$.
- Function name should be lowercase
- Variable in function should be lowercase

Fixes #77