### PR TITLE
Removed dependency on WMIC

### DIFF
--- a/config_files/config.py
+++ b/config_files/config.py
@@ -168,7 +168,7 @@ use_jit = True
 # gpu_collectors_count is the number of Trackmania instances that will be launched in parallel.
 # It is recommended that users adjust this number depending on the performance of their machine.
 # We recommend trying different values and finding the one that maximises the number of batches done per unit of time.
-gpu_collectors_count = 6
+gpu_collectors_count = 2
 
 send_shared_network_every_n_batches = 10
 update_inference_network_every_n_actions = 20

--- a/config_files/config.py
+++ b/config_files/config.py
@@ -168,7 +168,7 @@ use_jit = True
 # gpu_collectors_count is the number of Trackmania instances that will be launched in parallel.
 # It is recommended that users adjust this number depending on the performance of their machine.
 # We recommend trying different values and finding the one that maximises the number of batches done per unit of time.
-gpu_collectors_count = 2
+gpu_collectors_count = 6
 
 send_shared_network_every_n_batches = 10
 update_inference_network_every_n_actions = 20

--- a/trackmania_rl/tmi_interaction/game_instance_manager.py
+++ b/trackmania_rl/tmi_interaction/game_instance_manager.py
@@ -210,12 +210,18 @@ class GameInstanceManager:
 
             tmi_process_id = int(subprocess.check_output(launch_string).decode().split("\r\n")[1])
             while self.tm_process_id is None:
-                tm_processes = list(
-                    filter(
-                        lambda s: s.startswith("TmForever"),
-                        subprocess.check_output("wmic process get Caption,ParentProcessId,ProcessId").decode().split("\r\n"),
-                    )
+                output = subprocess.check_output(
+                    [
+                        "powershell",
+                        "-Command",
+                        "Get-CimInstance Win32_Process | "
+                        "Where-Object {$_.Name -eq 'TmForever.exe'} | "
+                        "ForEach-Object { \"$($_.Name) $($_.ParentProcessId) $($_.ProcessId)\" }"
+                    ],
+                    text=True,
                 )
+
+                tm_processes = output.strip().splitlines()
                 for process in tm_processes:
                     name, parent_id, process_id = process.split()
                     parent_id = int(parent_id)


### PR DESCRIPTION
This PR removes the dependency on wmic, which has been deprecated and is no longer included in modern Windows versions (Windows 10 21H1+ and Windows 11). Linesight currently uses wmic to detect running TrackMania processes, which causes failures on systems where wmic is unavailable.

This update replaces the wmic call with a supported, modern method for enumerating processes, restoring compatibility with all current Windows installations.

Closes #98 